### PR TITLE
Update @appcues/react-native to 5.0.3

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Appcues (5.0.0)
-  - appcues-react-native (5.0.2):
-    - Appcues (~> 5.0.0)
+  - Appcues (5.0.1)
+  - appcues-react-native (5.0.3):
+    - Appcues (~> 5.0.1)
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1920,8 +1920,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Appcues: d04033bf9e6a6f9803a2f6e466f0a433010a1a87
-  appcues-react-native: e62d57024dfb8581926b364506e639db01e31c47
+  Appcues: 2a3ac9ea789760c910d1159e2c9c7397b5448ecc
+  appcues-react-native: 3de8f600ca1cad98afd941f92b63a9a6265d1897
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -1929,72 +1929,72 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: 1f783c3d53940aed0d2c84586f0b7a85ab7827ef
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: f5c19ebdb8804b53ed029123eb69914356192fc8
   RCTRequired: 6ae6cebe470486e0e0ce89c1c0eabb998e7c51f4
   RCTTypeSafety: 50d6ec72a3d13cf77e041ff43a0617050fb98e3f
   React: e46fdbd82d2de942970c106677056f3bdd438d82
   React-callinvoker: b027ad895934b5f27ce166d095ed0d272d7df619
-  React-Core: 36b7f20f655d47a35046e2b02c9aa5a8f1bcb61e
-  React-CoreModules: 7fac6030d37165c251a7bd4bde3333212544da3c
-  React-cxxreact: 0ead442ecaa248e7f71719e286510676495ae26d
+  React-Core: 92733c8280b1642afed7ebfb3c523feaec946ece
+  React-CoreModules: e2dfd87b6fdb9d969b16871655885a4d89a2a9f4
+  React-cxxreact: d1a70e78543bb5b159fdaf6c52cadd33c1ae3244
   React-debug: 78d7544d2750737ac3acc88cca2f457d081ec43d
-  React-defaultsnativemodule: 833b618f562a7798e7a814ce1ddc001464d7a3d0
-  React-domnativemodule: c1ca50f25913f73d5e95d55ff5352e7f1d7ebcc8
-  React-Fabric: 131631b99737169826d16290d5b90c53a150fc15
-  React-FabricComponents: 1f6ce42418da316663f53b534bdebd23ec4be41f
-  React-FabricImage: b6ba029f882f1676cb1b59688fa39e1ef0814381
+  React-defaultsnativemodule: b24e61fe2d5bb84501898683f9d13ff7fc02a9df
+  React-domnativemodule: 210ca3670f16ae92fbcff8da204750af8a7295af
+  React-Fabric: 4b3d03ea38646dcc80888253c2befca80526abed
+  React-FabricComponents: 38fcb6f5c08f8de9e693f2644d2da54ae4fbf6c8
+  React-FabricImage: 1d37769002c13dfffa9f53557a173d56c9ade5e3
   React-featureflags: 92dd7d0169ab0bf8ad404a5fe757c1ca7ccd74e8
-  React-featureflagsnativemodule: 69bc086433eff3077b90f4ea17ab2083ad281868
-  React-graphics: f09d013df7aef5551fdce4c99f2fe704c6c5b35a
-  React-hermes: 13e1c1c9222503bcd7ad450370c5a26dc9b46ebe
-  React-idlecallbacksnativemodule: f349708531f44d3db8ac79129d8e2b4d8cc3d1ff
-  React-ImageManager: e20f7c0291e5c9298b643c88b40db62c46a30ae4
-  React-jserrorhandler: 79aa6ef93470ab9e8f4c6c6258dc662880b0bfb4
-  React-jsi: 931610846e52e5d157f4bc3f71a14f9a53573abd
-  React-jsiexecutor: 3f5fb21d47c5c72c13a1710b288d78c8209a38f9
-  React-jsinspector: d2653e42aae27f01f71f10ab87866cf092288e30
-  React-jsitracing: fe93bab4193ec5528bcbdaf2f1b62475652490ad
-  React-logger: 9a0c4e1e41cd640ac49d69aacadab783f7e0096b
-  React-Mapbuffer: 6993c785c22a170c02489bc78ed207814cbd700f
-  React-microtasksnativemodule: 19230cd0933df6f6dc1336c9a9edc382d62638ae
-  react-native-get-random-values: 21325b2244dfa6b58878f51f9aa42821e7ba3d06
-  react-native-safe-area-context: 337fce5941460e2605fb3c39dbb0f6e0765c8010
+  React-featureflagsnativemodule: 8a6373d7b4ef3c08d82b60376f75bd189bfc8cb2
+  React-graphics: 2b316fcf5b6c29ded7d53ae0007d1d129dc89510
+  React-hermes: bf50c8272cb562300a54a621aa69dc12a0b4fcf2
+  React-idlecallbacksnativemodule: 47df5b6649ca5e0046aa3e43e680452007b16871
+  React-ImageManager: 83b8dc67e97cd5fe10cb715bd878aded16adb40f
+  React-jserrorhandler: ac08c5673dea69b08e11faf074fd602fbf9492cc
+  React-jsi: 19e77567e235d06b7e8f425d2a6c1e948ab286e9
+  React-jsiexecutor: fe6ad8b9a2bf97e435fc1c969c80ed7f447ed68e
+  React-jsinspector: f321d958a5534b65b56f7806c674e159c28f7d69
+  React-jsitracing: d358876acde46009f391228b932a5efe13c8895b
+  React-logger: 02e5802824aa9b15cb7df42e10a91abead83cd8d
+  React-Mapbuffer: 99bd566147aaa78e872568be53ebca8a4449ddae
+  React-microtasksnativemodule: 51e7813abf875408a0f367e473a65bbab6aa8481
+  react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
+  react-native-safe-area-context: 90db9cb1243ba193ef6d05b26ff0600e69112214
   React-nativeconfig: cd0fbb40987a9658c24dab5812c14e5522a64929
-  React-NativeModulesApple: 45187d13c68d47250a7416b18ff082c7cc07bff7
-  React-perflogger: 15a7bcb6c46eae8a981f7add8c9f4172e2372324
-  React-performancetimeline: 631ef8ac4246bca49c07b88cd1ad85ce460b97bf
+  React-NativeModulesApple: 4a9c304aa4fb086af32e8758ba892386d895b4d3
+  React-perflogger: 721172bda31a65ce7b7a0c3bf3de96f12ef6f45d
+  React-performancetimeline: 46dbe9fd618ff882f59600dcd9fa923a9713cc3b
   React-RCTActionSheet: 25eb72eabade4095bfaf6cd9c5c965c76865daa8
-  React-RCTAnimation: 04c987fa858fa16169f543d29edb4140bd35afa9
-  React-RCTAppDelegate: b2707904e4f8ad92fd052e62684bf0c3b88381cc
-  React-RCTBlob: 1f214a7211632515805dd1f1b81fac70d12f812d
-  React-RCTFabric: 10f8b1ceac3c2feb3ddbede8a70c3410c68d79fe
-  React-RCTFBReactNativeSpec: 60d72b45a150ca35748b9a77028674b1e56a2e43
-  React-RCTImage: e516d72739797fb7c1dac5c691f02a0f5445c290
-  React-RCTLinking: 1e5554afe4f959696ad3285738c1510f2592f220
-  React-RCTNetwork: 65e1e52c8614dcab342fa1eaec750ca818160e74
-  React-RCTSettings: e86c204b481ef9264929fe00d1fdd04ce561748a
-  React-RCTText: 15f14d6f9b75e64ffe749c75e30ff047cf0fa1be
-  React-RCTVibration: 8d9078d5432972fe12d9f1526b38f504ad3d45cb
+  React-RCTAnimation: 8efbd0a4a71fd3dbe84e6d08b92bec5728b7524b
+  React-RCTAppDelegate: 8ff6da817adefd15d4e25ade53a477c344f9b213
+  React-RCTBlob: 6056bd62a56a6d2dad55cdf195949db1de623e14
+  React-RCTFabric: 949589de63c19b8b197555567fbc51eebd265bbc
+  React-RCTFBReactNativeSpec: 4214925b1c4829fb1e73bfbacb301244b522dc11
+  React-RCTImage: 7b3f38c77e183bdcb43dbcd7b5842b96c814889a
+  React-RCTLinking: 6cca74db71b23f670b72e45603e615c2b72b2235
+  React-RCTNetwork: 5791b0718eff20c12f6f3d62e2ad50cff4b5c8a0
+  React-RCTSettings: 84154e31a232b5b03b6b7a89924a267c431ccf16
+  React-RCTText: cd49cb4442ee7f64b0415b27745d2495cb40cfaa
+  React-RCTVibration: 2a7432e61d42f802716bd67edc793b5e5f58971a
   React-rendererconsistency: 7a81b08f01655b458d1de48ddd5b3f5988fd753f
-  React-rendererdebug: 28f591de2009cb053e21cbf87edb357e6b214147
+  React-rendererdebug: a6547cf2f3f7bcdd8d36ff5e103145d83f5001d4
   React-rncore: dd08c91cea25486f79012e32975c0ea26bd92760
-  React-RuntimeApple: fc7a3fe49564bd6a5b8aef081341960212ab58d0
-  React-RuntimeCore: 2f967e25ca18a85cff22d103fbe782828442eeb4
+  React-RuntimeApple: ea09b4c38df2695e0cb3fa60a83db81d653a39fd
+  React-RuntimeCore: 3dc763d365a1f738d92cd942066dd347953733f3
   React-runtimeexecutor: f9ae11481be048438640085c1e8266d6afebae44
-  React-RuntimeHermes: e2160a175c7a34dad30b0e10d79e8d70da471beb
-  React-runtimescheduler: 07601cb38739f60ddb2f9efb854a13cfb48310dd
+  React-RuntimeHermes: 3bc16b5a5a756a292ad6f56968dfb8de643ae20b
+  React-runtimescheduler: 2e90401c400b62bb720d6ac028dcef803e30d888
   React-timing: 0d0263a5d8ab6fc8c325efb54cee1d6a6f01d657
-  React-utils: 015e250e7898047068792d4b532fed21f2eb1661
-  ReactAppDependencyProvider: 3d947e9d62f351c06c71497e1be897e6006dc303
-  ReactCodegen: 1baa534318b19e95fb0f02db0a1ae1e3c271944d
-  ReactCommon: 6014af4276bb2debc350e2620ef1bd856b4d981c
-  RNCAsyncStorage: efa02b644121f4e1f7f33e712f4f82c30aa4ff4a
-  RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
-  RNVectorIcons: 3a2173c340d645b9af2dfe39801ae470a1b0a9a7
-  segment-analytics-react-native: 05c3bf2adb8a3be2c273808a6fdaced06d927917
+  React-utils: 8905cd01f46755ea42268875d04c614a0d46431e
+  ReactAppDependencyProvider: 6e8d68583f39dc31ee65235110287277eb8556ef
+  ReactCodegen: c08a5113d9c9c895fe10f3c296f74c6b705a60a9
+  ReactCommon: 1bd2dc684d7992acbf0dfee887b89a57a1ead86d
+  RNCAsyncStorage: 79cfba789fca205b204f3ce7948b874500129eb4
+  RNScreens: 790123c4a28783d80a342ce42e8c7381bed62db1
+  RNVectorIcons: 0e915baaf807d5dfed506a14f23a29476c1f07f9
+  segment-analytics-react-native: 0eae155b0e9fa560fa6b17d78941df64537c35b7
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  sovran-react-native: eec37f82e4429f0e3661f46aaf4fcd85d1b54f60
+  sovran-react-native: a3ad3f8ff90c2002b2aa9790001a78b0b0a38594
   Yoga: 78d74e245ed67bb94275a1316cdc170b9b7fe884
 
 PODFILE CHECKSUM: ead324b12c6a7cf782bb55ca89966b03d600917b

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "segment-appcues-react-native-example",
       "version": "5.0.2",
       "dependencies": {
-        "@appcues/react-native": "^5.0.2",
+        "@appcues/react-native": "^5.0.3",
         "@appcues/segment-react-native": "file:..",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-navigation/bottom-tabs": "^7.2.0",
@@ -41,7 +41,7 @@
     },
     "..": {
       "name": "@appcues/segment-react-native",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -62,14 +62,18 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@appcues/react-native": "^5.0.2",
+        "@appcues/react-native": "^5.0.3",
         "@segment/analytics-react-native": "*"
       }
     },
     "node_modules/@appcues/react-native": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.2.tgz",
-      "integrity": "sha512-Ry9G/EZ63syGQXwaU72ZQbQ4uHoVOtR7xJ+Ji1qIiur1UH8OkkW/usYIM350ax79D9BIIjJnQ+VaRu77v3BAyw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.3.tgz",
+      "integrity": "sha512-xhwjEQIUenFdt9gxYc+rgGMZ57a/3csRGOM9+6TWYXB5eDCh4u7euYfjSPbqjMDRgKA7nZkF6LFl44fP98Xw3A==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "@appcues/react-native": "^5.0.2",
+    "@appcues/react-native": "^5.0.3",
     "@appcues/segment-react-native": "file:..",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-navigation/bottom-tabs": "^7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@appcues/react-native": "^5.0.2",
+        "@appcues/react-native": "^5.0.3",
         "@segment/analytics-react-native": "*"
       }
     },
@@ -42,10 +42,14 @@
       }
     },
     "node_modules/@appcues/react-native": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.2.tgz",
-      "integrity": "sha512-Ry9G/EZ63syGQXwaU72ZQbQ4uHoVOtR7xJ+Ji1qIiur1UH8OkkW/usYIM350ax79D9BIIjJnQ+VaRu77v3BAyw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@appcues/react-native/-/react-native-5.0.3.tgz",
+      "integrity": "sha512-xhwjEQIUenFdt9gxYc+rgGMZ57a/3csRGOM9+6TWYXB5eDCh4u7euYfjSPbqjMDRgKA7nZkF6LFl44fP98Xw3A==",
+      "license": "MIT",
       "peer": true,
+      "workspaces": [
+        "example"
+      ],
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@appcues/react-native": "^5.0.2",
+    "@appcues/react-native": "^5.0.3",
     "@segment/analytics-react-native": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily a dependency bump, but it updates native iOS pods and React Native-related checksums, which could cause build/runtime regressions on iOS if upstream changes are incompatible.
> 
> **Overview**
> Updates `@appcues/react-native` from `5.0.2` to `5.0.3` across the example app and the library’s `peerDependencies`.
> 
> Refreshes lockfiles (`package-lock.json`, `example/package-lock.json`) and iOS CocoaPods state (`example/ios/Podfile.lock`) to align with the new Appcues/Appcues React Native pod versions and resulting checksum changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b28f9f8216762705e1f9dbadf5d3ac09e167e6d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->